### PR TITLE
Add WeatherSnapHelper

### DIFF
--- a/app/src/main/kotlin/com/thoughtbot/tropos/extensions/ViewExtensions.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/extensions/ViewExtensions.kt
@@ -1,6 +1,8 @@
 package com.thoughtbot.tropos.extensions
 
 import android.graphics.Color
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.SnapHelper
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
@@ -22,3 +24,6 @@ fun String.colorSubString(subString: String, color: Int): SpannableStringBuilder
   return stringBuilder
 }
 
+fun RecyclerView.attachSnapHelper(snapHelper: SnapHelper) {
+  snapHelper.attachToRecyclerView(this)
+}

--- a/app/src/main/kotlin/com/thoughtbot/tropos/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/main/MainActivity.kt
@@ -7,6 +7,7 @@ import android.support.v7.widget.RecyclerView
 import com.thoughtbot.tropos.R
 import com.thoughtbot.tropos.commons.BaseActivity
 import com.thoughtbot.tropos.commons.ViewBinder
+import com.thoughtbot.tropos.extensions.attachSnapHelper
 import com.thoughtbot.tropos.permissions.getPermissionResults
 import com.thoughtbot.tropos.refresh.PullToRefreshLayout
 import com.thoughtbot.tropos.refresh.RefreshDrawable
@@ -28,6 +29,9 @@ class MainActivity : BaseActivity(), MainView {
 
     pullToRefreshLayout.setRefreshingDrawable(RefreshDrawable(this))
     pullToRefreshLayout.refreshListener = presenter
+
+    val snapHelper = WeatherSnapHelper()
+    recyclerView.attachSnapHelper(snapHelper)
 
     presenter.init()
   }

--- a/app/src/main/kotlin/com/thoughtbot/tropos/main/WeatherSnapHelper.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/main/WeatherSnapHelper.kt
@@ -1,0 +1,62 @@
+package com.thoughtbot.tropos.main
+
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.LinearSnapHelper
+import android.support.v7.widget.OrientationHelper
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.RecyclerView.LayoutManager
+import android.view.View
+
+/**
+ * Implementation of {@link LinearSnapHelper} that is designed to work exclusively
+ * with {@link WeatherAdapter} and its' attached {@link RecyclerView}
+ *
+ * The implementation will snap to either completely show or hide the {@link ForecastViewHolder}
+ * depending on how much of it is visible on when user releases their touch
+ **/
+class WeatherSnapHelper : LinearSnapHelper() {
+
+  override fun findSnapView(layoutManager: LayoutManager?): View? {
+    layoutManager as LinearLayoutManager
+
+    val lastChildIndex = layoutManager.findLastVisibleItemPosition()
+    if (lastChildIndex == RecyclerView.NO_POSITION) {
+      return null
+    }
+
+    val lastChild = layoutManager.findViewByPosition(lastChildIndex)
+    val orientationHelper = OrientationHelper.createVerticalHelper(layoutManager)
+    val lastChildStart = orientationHelper.getDecoratedStart(lastChild)
+    val lastChildHeight = orientationHelper.getDecoratedMeasurement(lastChild)
+    val recyclerViewHeight = layoutManager.height
+
+    //amount of the the forecast (last child) height that is visible on screen
+    val visibleHeight = recyclerViewHeight - lastChildStart
+
+    //if more than half of the forecast is visible, snap to it, else snap to the weather
+    if (visibleHeight > (lastChildHeight / 2)) {
+      return lastChild
+    } else {
+      return layoutManager.findViewByPosition(0)
+    }
+  }
+
+  override fun calculateDistanceToFinalSnap(layoutManager: LayoutManager, target: View): IntArray? {
+    val out = IntArray(2)
+    out[0] = 0
+
+    val targetViewType = layoutManager.getItemViewType(target)
+    val weatherViewType = layoutManager.getItemViewType(layoutManager.findViewByPosition(0))
+    val orientationHelper = OrientationHelper.createVerticalHelper(layoutManager)
+
+    if (targetViewType == weatherViewType) {
+      // snap to show weather
+      out[1] = orientationHelper.getDecoratedStart(target) - orientationHelper.startAfterPadding
+    } else {
+      // snap to show forecasts
+      out[1] = orientationHelper.getDecoratedEnd(target) - orientationHelper.endAfterPadding
+    }
+    return out
+  }
+
+}


### PR DESCRIPTION
## 🔧 changes
- Add `WeatherSnapHelper` a custom implementation of `LinearSnapHelper` that will automatically snap the `RecyclerView` to either completely show or hide the forecast items if more than half of their height is visible

## 📷  screenshot
<img src="https://cloud.githubusercontent.com/assets/5386934/22120897/8bc57a50-de36-11e6-98c3-4315b861eddf.gif" width=300/>
