### PR TITLE
Add A Splash Screen (that is actually used)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
     android:theme="@style/AppTheme">
 
     <activity
-      android:name=".ui.MainActivity"
+      android:name=".splash.SplashActivity"
       android:screenOrientation="portrait"
       android:theme="@style/AppTheme.TransparentStatusBar">
       <intent-filter>
@@ -22,6 +22,12 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
+
+    <activity
+      android:name=".ui.MainActivity"
+      android:screenOrientation="portrait"
+      android:theme="@style/AppTheme.TransparentStatusBar"
+      />
 
   </application>
 

--- a/app/src/main/kotlin/com/thoughtbot/tropos/data/WeatherService.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/data/WeatherService.kt
@@ -1,26 +1,36 @@
 package com.thoughtbot.tropos.data
 
 import android.content.Context
+import android.content.Intent
 import com.thoughtbot.tropos.data.remote.ConditionDataService
 import com.thoughtbot.tropos.data.remote.LocationService
 import com.thoughtbot.tropos.extensions.dayBefore
+import com.thoughtbot.tropos.ui.MainActivity
 import io.reactivex.Observable
 import java.util.Date
 
 class WeatherService(
     val context: Context,
+    intent: Intent?,
     val locationDataSource: LocationDataSource = LocationService(context),
     val conditionDataSource: ConditionDataSource = ConditionDataService()) : WeatherDataSource {
 
+  val weather: Weather? = intent?.getParcelableExtra(MainActivity.WEATHER_EXTRA)
+  var initialRequest = true
+
   override fun fetchWeather(): Observable<Weather> {
-    return locationDataSource.fetchLocation()
-        .flatMap { conditionDataSource.fetchForecast(it, 3) }
-        .flatMap({ forecast ->
-          conditionDataSource.fetchCondition(forecast[0].location, Date().dayBefore())
-        }, { forecast, yesterday ->
-          return@flatMap Weather(yesterday, forecast[0], forecast.drop(1))
-        })
+    if (weather != null && initialRequest) {
+      //only return the Weather from Intent on initial request, subsequent calls should hit the API
+      initialRequest = false
+      return Observable.just(weather)
+    } else {
+      return locationDataSource.fetchLocation()
+          .flatMap { conditionDataSource.fetchForecast(it, 3) }
+          .flatMap({ forecast ->
+            conditionDataSource.fetchCondition(forecast[0].location, Date().dayBefore())
+          }, { forecast, yesterday ->
+            return@flatMap Weather(yesterday, forecast[0], forecast.drop(1))
+          })
+    }
   }
-
 }
-

--- a/app/src/main/kotlin/com/thoughtbot/tropos/splash/SplashActivity.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/splash/SplashActivity.kt
@@ -1,0 +1,41 @@
+package com.thoughtbot.tropos.splash
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.support.v4.app.ActivityCompat.finishAfterTransition
+import com.thoughtbot.tropos.R
+import com.thoughtbot.tropos.commons.BaseActivity
+import com.thoughtbot.tropos.permissions.getPermissionResults
+
+class SplashActivity : BaseActivity(), SplashView {
+
+  val presenter: SplashPresenter by lazy { SplashPresenter(this) }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_splash)
+
+    presenter.init()
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    presenter.onDestroy()
+  }
+
+  override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>,
+      grantResults: IntArray) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    getPermissionResults(presenter.permission, presenter, requestCode, permissions, grantResults)
+  }
+
+  override val context: Context = this
+
+  override fun navigate(intent: Intent) {
+    startActivity(intent)
+    overridePendingTransition(R.anim.slide_in, R.anim.slide_out)
+    finishAfterTransition(this)
+  }
+
+}

--- a/app/src/main/kotlin/com/thoughtbot/tropos/splash/SplashPresenter.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/splash/SplashPresenter.kt
@@ -1,0 +1,44 @@
+package com.thoughtbot.tropos.splash
+
+import com.thoughtbot.tropos.commons.Presenter
+import com.thoughtbot.tropos.data.WeatherDataSource
+import com.thoughtbot.tropos.data.WeatherService
+import com.thoughtbot.tropos.permissions.LocationPermission
+import com.thoughtbot.tropos.permissions.Permission
+import com.thoughtbot.tropos.permissions.PermissionResults
+import com.thoughtbot.tropos.permissions.checkPermission
+import com.thoughtbot.tropos.ui.MainActivity
+import io.reactivex.disposables.Disposable
+
+class SplashPresenter(override val view: SplashView,
+    val permission: Permission = LocationPermission(view.context),
+    val weatherDataSource: WeatherDataSource = WeatherService(view.context, null))
+  : Presenter, PermissionResults {
+
+  var disposable: Disposable? = null
+
+  fun init() {
+    permission.checkPermission({ fetchWeather() }, { onPermissionDenied(false) }, true)
+  }
+
+  fun onDestroy() {
+    disposable?.dispose()
+  }
+
+  override fun onPermissionGranted() {
+    fetchWeather()
+  }
+
+  override fun onPermissionDenied(userSaidNever: Boolean) {
+    view.navigate(MainActivity.createIntent(view.context, null))
+  }
+
+  private fun fetchWeather() {
+    disposable = weatherDataSource.fetchWeather()
+        .subscribe({
+          view.navigate(MainActivity.createIntent(view.context, it))
+        }, { error ->
+          view.navigate(MainActivity.createIntent(view.context, null))
+        })
+  }
+}

--- a/app/src/main/kotlin/com/thoughtbot/tropos/splash/SplashView.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/splash/SplashView.kt
@@ -1,0 +1,8 @@
+package com.thoughtbot.tropos.splash
+
+import android.content.Intent
+import com.thoughtbot.tropos.commons.View
+
+interface SplashView : View {
+  fun navigate(intent: Intent)
+}

--- a/app/src/main/kotlin/com/thoughtbot/tropos/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/ui/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.thoughtbot.tropos.ui
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.support.v7.widget.GridLayoutManager
 import android.support.v7.widget.RecyclerView
@@ -9,6 +10,7 @@ import com.thoughtbot.tropos.R
 import com.thoughtbot.tropos.adapters.WeatherAdapter
 import com.thoughtbot.tropos.commons.BaseActivity
 import com.thoughtbot.tropos.commons.ViewBinder
+import com.thoughtbot.tropos.data.Weather
 import com.thoughtbot.tropos.extensions.attachSnapHelper
 import com.thoughtbot.tropos.permissions.getPermissionResults
 import com.thoughtbot.tropos.refresh.PullToRefreshLayout
@@ -22,8 +24,17 @@ import kotlinx.android.synthetic.main.activity_main.toolbar_last_update
 import org.jetbrains.anko.find
 
 class MainActivity : BaseActivity(), MainView {
+  companion object {
+    val WEATHER_EXTRA = "weather_extra"
 
-  val presenter: MainPresenter by lazy { MainPresenter(this) }
+    fun createIntent(context: Context, weather: Weather?): Intent {
+      val intent = Intent(context, MainActivity::class.java)
+      weather?.let { intent.putExtra(WEATHER_EXTRA, it) }
+      return intent
+    }
+  }
+
+  val presenter: MainPresenter by lazy { MainPresenter(this, intent) }
   val recyclerView: RecyclerView by lazy { findViewById(R.id.recycler_view) as RecyclerView }
   val adapter: WeatherAdapter by lazy { WeatherAdapter() }
   val layoutManager: GridLayoutManager by lazy { GridLayoutManager(this, 3) }
@@ -41,8 +52,11 @@ class MainActivity : BaseActivity(), MainView {
 
     pullToRefreshLayout.setRefreshingDrawable(RefreshDrawable(this))
     pullToRefreshLayout.refreshListener = presenter
+  }
 
-    presenter.init()
+  override fun onResume() {
+    super.onResume()
+    presenter.onResume()
   }
 
   override fun onDestroy() {

--- a/app/src/main/kotlin/com/thoughtbot/tropos/ui/MainPresenter.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/ui/MainPresenter.kt
@@ -1,5 +1,6 @@
 package com.thoughtbot.tropos.ui
 
+import android.content.Intent
 import com.thoughtbot.tropos.R
 import com.thoughtbot.tropos.commons.Presenter
 import com.thoughtbot.tropos.data.WeatherDataSource
@@ -15,13 +16,14 @@ import com.thoughtbot.tropos.viewmodels.WeatherToolbarViewModel
 import io.reactivex.disposables.Disposable
 
 class MainPresenter(override val view: MainView,
-    val weatherDataSource: WeatherDataSource = WeatherService(view.context),
+    intent: Intent?,
+    val weatherDataSource: WeatherDataSource = WeatherService(view.context, intent),
     val permission: Permission = LocationPermission(view.context))
   : Presenter, RefreshListener, PermissionResults {
 
-  lateinit var disposable: Disposable
+  var disposable: Disposable? = null
 
-  fun init() {
+  fun onResume() {
     permission.checkPermission({ updateWeather() }, { onPermissionDenied(false) }, true)
   }
 
@@ -42,7 +44,7 @@ class MainPresenter(override val view: MainView,
   }
 
   fun onDestroy() {
-    disposable.dispose()
+    disposable?.dispose()
   }
 
   override fun onPermissionGranted() {

--- a/app/src/main/res/anim/slide_in.xml
+++ b/app/src/main/res/anim/slide_in.xml
@@ -1,0 +1,6 @@
+<translate
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:duration="1000"
+  android:fromYDelta="90%p"
+  android:toYDelta="0%p">
+</translate>

--- a/app/src/main/res/anim/slide_out.xml
+++ b/app/src/main/res/anim/slide_out.xml
@@ -1,0 +1,6 @@
+<translate
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:duration="1000"
+  android:fromYDelta="0"
+  android:toYDelta="-90%p">
+</translate>

--- a/app/src/main/res/drawable/stripes.xml
+++ b/app/src/main/res/drawable/stripes.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:height="264dp"
+  android:viewportHeight="264"
+  android:viewportWidth="520"
+  android:width="520dp">
+  <path
+    android:fillColor="#76D5F0"
+    android:pathData="M4,194 L520,194 L520,264 L0,264 L0,194 Z"
+    android:strokeWidth="1" />
+  <path
+    android:fillColor="#20B7EA"
+
+    android:pathData="M4,130 L520,130 L520,194 L0,194 L0,130 Z"
+    android:strokeWidth="1" />
+  <path
+    android:fillColor="#F5A328"
+    android:pathData="M4,66 L520,66 L520,130 L0,130 L0,66 Z"
+    android:strokeWidth="1" />
+  <path
+    android:fillColor="#E95337"
+    android:pathData="M4,0 L520,0 L520,66 L0,66 L0,0 Z"
+    android:strokeWidth="1" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -59,7 +59,7 @@
       android:padding="20dp"
       android:textColor="@color/cloud_gray"
       android:textSize="24sp"
-      android:visibility="visible"
+      android:visibility="gone"
       tools:text="@string/missing_location_permission_error" />
 
     <LinearLayout
@@ -69,7 +69,8 @@
       android:layout_height="wrap_content"
       android:layout_gravity="bottom"
       android:orientation="vertical"
-      android:padding="8dp">
+      android:padding="8dp"
+      android:visibility="gone">
 
       <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:background="@color/primary_background"
+  android:orientation="vertical">
+
+  <ImageView
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom"
+    android:background="@drawable/stripes" />
+
+</FrameLayout>

--- a/app/src/test/kotlin/com/thoughtbot/tropos/splash/SplashPresenterTest.kt
+++ b/app/src/test/kotlin/com/thoughtbot/tropos/splash/SplashPresenterTest.kt
@@ -1,0 +1,99 @@
+package com.thoughtbot.tropos.splash
+
+import android.content.Context
+import android.location.Location
+import com.nhaarman.mockito_kotlin.isA
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import com.thoughtbot.tropos.BuildConfig
+import com.thoughtbot.tropos.data.Condition
+import com.thoughtbot.tropos.data.Icon
+import com.thoughtbot.tropos.data.Weather
+import com.thoughtbot.tropos.data.WeatherDataSource
+import com.thoughtbot.tropos.data.WindDirection
+import com.thoughtbot.tropos.permissions.Permission
+import com.thoughtbot.tropos.ui.MainActivity
+import com.thoughtbot.tropos.ui.MainPresenter
+import com.thoughtbot.tropos.ui.MainView
+import com.thoughtbot.tropos.ui.ViewState
+import io.reactivex.Observable
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricGradleTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.util.Date
+
+@RunWith(RobolectricGradleTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = intArrayOf(21))
+class SplashPresenterTest() {
+
+  lateinit var context: Context
+  val view = mock<SplashView>()
+  val permission = mock<Permission>()
+  val weatherDataSource = mock<WeatherDataSource>()
+
+  val mockCondition: Condition = {
+    val timeStamp = 1484180189 * 1000L // equivalent to Wed Jan 11 16:16:29 PST 2017
+    val date = Date(timeStamp)
+    val summary = "Mostly Cloudy"
+    val location = Location("")
+    location.longitude = -122.4375671
+    location.latitude = 37.8032493
+    val icon = Icon.PARTLY_CLOUDY_DAY
+    val windSpeed = 4
+    val windDirection = WindDirection(171.0)
+    val lowTemp = 48
+    val highTemp = 54
+    val temp = 52
+
+    Condition(date, summary, location, icon, windSpeed, windDirection, lowTemp, temp,
+        highTemp)
+  }()
+
+  val mockWeather: Weather = Weather(mockCondition, mockCondition,
+      listOf(mockCondition, mockCondition, mockCondition))
+
+  @Before
+  fun setup() {
+    RuntimeEnvironment.application.let { context = it }
+  }
+
+  @Test
+  fun testInit_hasPermission() {
+    val presenter = SplashPresenter(view, permission, weatherDataSource)
+    whenever(view.context).thenReturn(context)
+    stubWeather()
+    stubPermission(true)
+
+    presenter.init()
+
+    val intent = MainActivity.createIntent(context, mockWeather)
+    verify(view).navigate(intent)
+  }
+
+  @Test
+  fun testInit_doesNotHavePermission() {
+    val presenter = SplashPresenter(view, permission, weatherDataSource)
+    whenever(view.context).thenReturn(context)
+    stubWeather()
+    stubPermission(false)
+
+    presenter.init()
+
+    val intent = MainActivity.createIntent(context, null)
+    verify(view).navigate(intent)
+  }
+
+  fun stubWeather() {
+    whenever(weatherDataSource.fetchWeather()).thenReturn(Observable.just(mockWeather))
+  }
+
+  fun stubPermission(hasPermission: Boolean) {
+    whenever(permission.hasPermission()).thenReturn(hasPermission)
+  }
+
+}
+

--- a/app/src/test/kotlin/com/thoughtbot/tropos/ui/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/thoughtbot/tropos/ui/MainPresenterTest.kt
@@ -1,4 +1,4 @@
-package com.thoughtbot.tropos
+package com.thoughtbot.tropos.ui
 
 import android.content.Context
 import android.location.Location
@@ -6,6 +6,7 @@ import com.nhaarman.mockito_kotlin.isA
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
+import com.thoughtbot.tropos.BuildConfig
 import com.thoughtbot.tropos.data.Condition
 import com.thoughtbot.tropos.data.Icon
 import com.thoughtbot.tropos.data.Weather
@@ -60,26 +61,26 @@ class MainPresenterTest() {
   }
 
   @Test
-  fun testInit_hasPermission() {
-    val presenter = MainPresenter(view, weatherDataSource, permission)
+  fun testOnResume_hasPermission() {
+    val presenter = MainPresenter(view, null, weatherDataSource, permission)
     whenever(view.context).thenReturn(context)
     stubWeather()
     stubPermission(true)
 
-    presenter.init()
+    presenter.onResume()
 
     verify(view).viewState = isA<ViewState.Loading>()
     verify(view).viewState = isA<ViewState.Weather>()
   }
 
   @Test
-  fun testInit_doesNotHavePermission() {
-    val presenter = MainPresenter(view, weatherDataSource, permission)
+  fun testOnResume_doesNotHavePermission() {
+    val presenter = MainPresenter(view, null, weatherDataSource, permission)
     whenever(view.context).thenReturn(context)
     stubWeather()
     stubPermission(false)
 
-    presenter.init()
+    presenter.onResume()
 
     verify(view).viewState = isA<ViewState.Error>()
   }


### PR DESCRIPTION
## 🔧 changes
- Add `SplashActivity` which handles fetching the weather to then pass onto `MainActivity` 

## 📝 notes
- I made the decision to ask for permission here so we can try our very best to fetch the weather here, in the splash state, before taking the user to the `MainActivity` screen. I didn't however want to deal with any error states or lack of permission stuff - as that is already baked into `MainPresenter`.
- This is based off #6 as the changes to add a single `Weather` model were necessary to reduce complexity and redundancy 

## 🎥 screenshot
<img src="https://cloud.githubusercontent.com/assets/5386934/22306648/d481b430-e2f4-11e6-9105-8dfbf44e0f8a.gif" width=300/>
