### PR TITLE
German Localization

### DIFF
--- a/app/src/main/kotlin/com/thoughtbot/tropos/viewmodels/CurrentWeatherViewModel.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/viewmodels/CurrentWeatherViewModel.kt
@@ -28,7 +28,7 @@ class CurrentWeatherViewModel(val context: Context, val today: Condition,
     val yesterday: Condition) {
 
   fun weatherSummary(): SpannableStringBuilder {
-    val adjective = tempDifference().name.toLowerCase()
+    val adjective = context.getString(tempDifference().asAdjective())
     val todayDescription = context.getString(timeOfDay().asPresentDayDescription())
     val yesterdayDescription = context.getString(timeOfDay().asPreviousDayDescription())
     val format = tempDifference().summaryFormat()
@@ -79,6 +79,14 @@ class CurrentWeatherViewModel(val context: Context, val today: Condition,
     } else {
       return color
     }
+  }
+
+  private fun TemperatureDifference.asAdjective(): Int = when(this) {
+    SAME -> R.string.same
+    HOTTER -> R.string.hotter
+    WARMER -> R.string.warmer
+    COOLER -> R.string.cooler
+    COLDER -> R.string.colder
   }
 
   private fun TimeOfDay.asPresentDayDescription(): Int {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    //directions
+    <string name="no_direction"></string>
+    <string name="north_abbrev">N</string>
+    <string name="north_east_abbrev">NO</string>
+    <string name="east_abbrev">O</string>
+    <string name="south_east_abbrev">SO</string>
+    <string name="south_abbrev">S</string>
+    <string name="south_west_abrrev">SW</string>
+    <string name="west_abbrev">W</string>
+    <string name="north_west_abbrev">NW</string>
+
+    //main
+    <string name="formatted_temperature_string">%1$d&#xb0; / %2$d&#xb0; / %3$d&#xb0;</string>
+    <string name="formatted_wind_string">%1$s mph %2$s</string>
+    <string name="temperature">%d&#xb0;</string>
+    <string name="missing_location_permission_error">🙅🏾 🙅🏼 🙅🏻\n\nStandortermittlung ist ausgeschaltet. \n\nSchalte die Standortermittlung in den Einstellungen an, damit wir dir eine präzise Wettervorhersage geben können.</string>
+    <string name="generic_error_message">🙅🏾 🙅🏼 🙅🏻\n\n%s</string>
+
+    //toolbar
+    <string name="updated_at">Aktualisiert um %s</string>
+    <string name="checking_weather">Rufe Wetter ab&#8230;</string>
+    <string name="update_failed">Aktualisierung fehlgeschlagen</string>
+
+    //time of day
+    <string name="present_night">heute Abend</string>
+    <string name="present_morning">heute Morgen</string>
+    <string name="present_day">heute</string>
+    <string name="present_afternoon">heute Nachmittag</string>
+    <string name="previous_night">gestern Abend</string>
+    <string name="previous_morning">gestern Morgen</string>
+    <string name="previous_day">gestern</string>
+    <string name="previous_afternoon">gestern Nachmittag</string>
+
+    //temperature difference
+    <string name="colder">kälter</string>
+    <string name="cooler">kühler</string>
+    <string name="same">ähnlich</string>
+    <string name="warmer">wärmer</string>
+    <string name="hotter">heißer</string>
+
+    //temperature formats
+    <string name="different_temperature_format" formatted="false">Es ist %2$s %1$s als %3$s.</string>
+    <string name="same_temperature_format" formatted="false">Es ist %2$s %1$s wie %3$s.</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,13 @@
   <string name="previous_day">yesterday</string>
   <string name="previous_afternoon">yesterday afternoon</string>
 
+  //temperature difference
+  <string name="colder">colder</string>
+  <string name="cooler">cooler</string>
+  <string name="same">same</string>
+  <string name="warmer">warmer</string>
+  <string name="hotter">hotter</string>
+
   //temperature formats
   <string name="different_temperature_format" formatted="false">It\'s %s %s than %s.</string>
   <string name="same_temperature_format" formatted="false">It\'s the %s %s as %s.</string>

--- a/app/src/test/kotlin/com/thoughtbot/tropos/viewmodels/CurrentWeatherViewModelTest.kt
+++ b/app/src/test/kotlin/com/thoughtbot/tropos/viewmodels/CurrentWeatherViewModelTest.kt
@@ -55,6 +55,16 @@ class CurrentWeatherViewModelTest() {
     assertTrue { expected.contentEquals(actual) }
   }
 
+  @Config(qualifiers = "de")
+  @Test
+  fun testGermanWeatherSummary() {
+    val viewModel = CurrentWeatherViewModel(context, mockCondition, mockCondition)
+    val expected = "Es ist heute Nachmittag ähnlich wie gestern Nachmittag."
+    val actual = viewModel.weatherSummary()
+
+    assertTrue { expected.contentEquals(actual) }
+  }
+
   @Test
   fun testIcon() {
     val viewModel = CurrentWeatherViewModel(context, mockCondition, mockCondition)


### PR DESCRIPTION
I wanted to make a localized German version of the app for myself, and decided to push the changes I made back upstream, in case you're interested :)

## 🔧 Changes
* Use string resources instead of Enum names for the temperature difference adjective
* Add strings.xml for German (de) locale.

## 📝 Notes
I've added a test that runs with the `de` qualifier and checks the summary for the German equivalent of "It's the same this afternoon as yesterday afternoon."
This test *should* succeed when ran in PST, but **right now, the test fails for me**, because I'm in a timezone where the `1484180189` timestamp is actually during the night, so the summary changes accordingly - which is correct behavior, but the tests are not setup to deal with timezone differences. This is actually making a few other tests fail as well.
@mandybess I feel like fixing this should be a separate issue, and not part of this PR, right?