### PR TITLE
Fix Settings WebView bug when loading privacy policy.

### DIFF
--- a/app/src/main/kotlin/com/thoughtbot/tropos/commons/WebviewActivity.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/commons/WebviewActivity.kt
@@ -28,6 +28,7 @@ class WebviewActivity : BaseActivity() {
     setContentView(R.layout.activity_webview)
 
     val url: String = intent?.getStringExtra(URL_EXTRA) ?: DEFAULT_URL
+    webview.webViewClient = WebViewClient()
     webview.loadUrl(url)
   }
 

--- a/app/src/main/kotlin/com/thoughtbot/tropos/settings/SettingsPresenter.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/settings/SettingsPresenter.kt
@@ -20,7 +20,7 @@ class SettingsPresenter(override val view: SettingsView,
   }
 
   fun onPrivacyClicked() {
-    val privacyUrl = "http://troposweather.com/privacy"
+    val privacyUrl = "https://troposweather.com/privacy"
     val intent = WebviewActivity.createIntent(view.context, privacyUrl)
     view.context.startActivity(intent)
   }


### PR DESCRIPTION
This PR addresses the following issues:

- When privacy policy in settings was tapped, webview would open to blank page. This was due to not properly setting a webview client prior to calling loadUrl()
- Webview would not load non-sure (http) urls, updated privacy policy url to use https instead.