### PR TITLE
Feature/settings unit change

### DIFF
--- a/app/src/main/kotlin/com/thoughtbot/tropos/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/ui/MainActivity.kt
@@ -15,7 +15,6 @@ import com.thoughtbot.tropos.adapters.WeatherAdapter
 import com.thoughtbot.tropos.commons.BaseActivity
 import com.thoughtbot.tropos.commons.ViewBinder
 import com.thoughtbot.tropos.data.Weather
-import com.thoughtbot.tropos.data.local.LocalPreferences
 import com.thoughtbot.tropos.extensions.attachSnapHelper
 import com.thoughtbot.tropos.permissions.getPermissionResults
 import com.thoughtbot.tropos.refresh.PullToRefreshLayout

--- a/app/src/main/kotlin/com/thoughtbot/tropos/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/thoughtbot/tropos/ui/MainActivity.kt
@@ -15,6 +15,7 @@ import com.thoughtbot.tropos.adapters.WeatherAdapter
 import com.thoughtbot.tropos.commons.BaseActivity
 import com.thoughtbot.tropos.commons.ViewBinder
 import com.thoughtbot.tropos.data.Weather
+import com.thoughtbot.tropos.data.local.LocalPreferences
 import com.thoughtbot.tropos.extensions.attachSnapHelper
 import com.thoughtbot.tropos.permissions.getPermissionResults
 import com.thoughtbot.tropos.refresh.PullToRefreshLayout
@@ -65,6 +66,15 @@ class MainActivity : BaseActivity(), MainView {
   override fun onStart() {
     super.onStart()
     presenter.onStart()
+  }
+
+  override fun onResume() {
+    super.onResume()
+
+    // Update weather adapter values
+    pullToRefreshLayout.setRefreshing(true)
+
+    adapter.notifyDataSetChanged()
   }
 
 


### PR DESCRIPTION
This PR addresses the following issue: 

- When the user changes the weather unit in Settings, the forecast temperatures did not change
- In onResume() of MainActivity, we make sure to update our adapter and refresh the layout.